### PR TITLE
Lambda function to create table in parquet format

### DIFF
--- a/functions/parquet/create-parquet-table/index.js
+++ b/functions/parquet/create-parquet-table/index.js
@@ -1,37 +1,45 @@
 'use strict';
 
-const AWS = require('aws-sdk');
-const athena = new AWS.Athena();
+const aws = require('aws-sdk');
+const AthenaExpress = require('athena-express')
+
+const fetchesDatabase = process.env.DATABASE;
+const s3BucketLocation = process.env.S3_BUCKET_LOCATION
+
+const athenaExpressConfig = {
+    aws,
+    db: fetchesDatabase,
+    s3: s3BucketLocation,
+    retry: 30000, // wait 30 seconds before re-checking query status
+    getStats: true,
+    skipResults: true
+};
+
+const athenaExpress = new AthenaExpress(athenaExpressConfig);
 
 console.info('Starting create parquet table function');
 
-exports.handler = function (e, ctx, cb) {
-    let fetchesDatabase = process.env.DATABASE
-    let fetchesTable = process.env.FETCHES_TABLE
-    let parquetTable = process.env.PARQUET_TABLE
-    let s3BucketLocation = process.env.S3_BUCKET_LOCATION
+exports.handler = async function (e, ctx, cb) {
+
+    const fetchesTable = process.env.FETCHES_TABLE
+    const parquetTable = process.env.PARQUET_TABLE
 
     //TODO: Add trigger for weekly run
 
     //TODO: Delete table and folder before re-creating it
 
-    console.info("Starting to run ctas query")
-    const params = {
-        QueryString:
-            `CREATE TABLE ${parquetTable} 
-            WITH (format = 'PARQUET', partitioned_by = ARRAY['parameter']) 
-            AS SELECT date.utc as date_utc, date.local as date_local, location, country, value, unit, city, attribution, averagingperiod, coordinates, sourcename, sourcetype, mobile, parameter 
-            FROM ${fetchesTable};`,
-        QueryExecutionContext: {
-            Database: `${fetchesDatabase}`
-        },
-        ResultConfiguration: {
-            OutputLocation: `${s3BucketLocation}`
-        }
+    const ctasQuery =
+        `CREATE TABLE ${parquetTable} 
+        WITH (format = 'PARQUET', partitioned_by = ARRAY['parameter']) 
+        AS SELECT date.utc as date_utc, date.local as date_local, location, country, value, unit, city, attribution, averagingperiod, coordinates, sourcename, sourcetype, mobile, parameter 
+        FROM ${fetchesTable};`
+
+    try {
+        console.info("Starting to run ctas query")
+        let results = await athenaExpress.query(ctasQuery);
+        return cb(null, results)
     }
-    athena.startQueryExecution(params, function (err, data) {
-        if (err) console.log(err, err.stack); // an error occurred
-        //TODO: Proper error handling
-        else console.log("successful", data); // successful response to start the query
-    });
+    catch (error) {
+        return cb(error)
+    }
 }

--- a/functions/parquet/create-parquet-table/index.js
+++ b/functions/parquet/create-parquet-table/index.js
@@ -26,7 +26,7 @@ exports.handler = async function (e, ctx, cb) {
 
     //TODO: Add trigger for weekly run
 
-    //TODO: Delete table and folder before re-creating it
+    const deleteQuery = `DROP TABLE ${parquetTable};`
 
     const ctasQuery =
         `CREATE TABLE ${parquetTable} 
@@ -35,8 +35,11 @@ exports.handler = async function (e, ctx, cb) {
         FROM ${fetchesTable};`
 
     try {
+        console.info(`Deleting ${parquetTable}`)
+        await athenaExpress.query(deleteQuery)
+
         console.info("Starting to run ctas query")
-        let results = await athenaExpress.query(ctasQuery);
+        let results = await athenaExpress.query(ctasQuery)
         return cb(null, results)
     }
     catch (error) {

--- a/functions/parquet/create-parquet-table/index.js
+++ b/functions/parquet/create-parquet-table/index.js
@@ -1,18 +1,37 @@
-// const axios = require('axios')
-// const url = 'http://checkip.amazonaws.com/';
+'use strict';
+
+const AWS = require('aws-sdk');
+const athena = new AWS.Athena();
 
 console.info('Starting create parquet table function');
 
 exports.handler = function (e, ctx, cb) {
+    let fetchesDatabase = process.env.DATABASE
+    let fetchesTable = process.env.FETCHES_TABLE
+    let parquetTable = process.env.PARQUET_TABLE
+    let s3BucketLocation = process.env.S3_BUCKET_LOCATION
 
-    //Add trigger
+    //TODO: Add trigger for weekly run
 
-    //Get S3 bucket, realtime-gzip-test
+    //TODO: Delete table and folder before re-creating it
 
-    //Run CTAS query
-
-
-    //Set up weekly
-
-
+    console.info("Starting to run ctas query")
+    const params = {
+        QueryString:
+            `CREATE TABLE ${parquetTable} 
+            WITH (format = 'PARQUET', partitioned_by = ARRAY['parameter']) 
+            AS SELECT date.utc as date_utc, date.local as date_local, location, country, value, unit, city, attribution, averagingperiod, coordinates, sourcename, sourcetype, mobile, parameter 
+            FROM ${fetchesTable};`,
+        QueryExecutionContext: {
+            Database: `${fetchesDatabase}`
+        },
+        ResultConfiguration: {
+            OutputLocation: `${s3BucketLocation}`
+        }
+    }
+    athena.startQueryExecution(params, function (err, data) {
+        if (err) console.log(err, err.stack); // an error occurred
+        //TODO: Proper error handling
+        else console.log("successful", data); // successful response to start the query
+    });
 }

--- a/functions/parquet/create-parquet-table/index.js
+++ b/functions/parquet/create-parquet-table/index.js
@@ -1,0 +1,18 @@
+// const axios = require('axios')
+// const url = 'http://checkip.amazonaws.com/';
+
+console.info('Starting create parquet table function');
+
+exports.handler = function (e, ctx, cb) {
+
+    //Add trigger
+
+    //Get S3 bucket, realtime-gzip-test
+
+    //Run CTAS query
+
+
+    //Set up weekly
+
+
+}

--- a/functions/parquet/create-parquet-table/index.js
+++ b/functions/parquet/create-parquet-table/index.js
@@ -24,8 +24,6 @@ exports.handler = async function (e, ctx, cb) {
     const fetchesTable = process.env.FETCHES_TABLE
     const parquetTable = process.env.PARQUET_TABLE
 
-    //TODO: Add trigger for weekly run
-
     const deleteQuery = `DROP TABLE ${parquetTable};`
 
     const ctasQuery =

--- a/functions/parquet/create-parquet-table/package.json
+++ b/functions/parquet/create-parquet-table/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "create-parquet-table",
+  "version": "1.0.0",
+  "description": "hello world sample for NodeJS",
+  "author": "Sruti Modekurty",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.18.0"
+  },
+  "scripts": {
+    "test": "mocha tests/unit/"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4"
+  }
+}

--- a/functions/parquet/create-parquet-table/package.json
+++ b/functions/parquet/create-parquet-table/package.json
@@ -5,6 +5,7 @@
   "author": "Sruti Modekurty",
   "license": "MIT",
   "dependencies": {
+    "athena-express": "^5.2.0",
     "aws-sdk": "^2.652.0",
     "axios": "^0.18.0"
   },

--- a/functions/parquet/create-parquet-table/package.json
+++ b/functions/parquet/create-parquet-table/package.json
@@ -5,6 +5,7 @@
   "author": "Sruti Modekurty",
   "license": "MIT",
   "dependencies": {
+    "aws-sdk": "^2.652.0",
     "axios": "^0.18.0"
   },
   "scripts": {

--- a/functions/parquet/create-parquet-table/package.json
+++ b/functions/parquet/create-parquet-table/package.json
@@ -10,10 +10,17 @@
     "axios": "^0.18.0"
   },
   "scripts": {
-    "test": "mocha tests/unit/"
+    "test": "mocha tests/unit/",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
     "mocha": "^6.1.4"
   }
 }

--- a/functions/parquet/template.yaml
+++ b/functions/parquet/template.yaml
@@ -17,6 +17,7 @@ Resources:
       CodeUri: create-parquet-table/
       Handler: index.handler
       Runtime: nodejs12.x
+      Timeout: 300 #5 minutes
       Environment:
         Variables:
           DATABASE: 

--- a/functions/parquet/template.yaml
+++ b/functions/parquet/template.yaml
@@ -17,6 +17,12 @@ Resources:
       CodeUri: create-parquet-table/
       Handler: index.handler
       Runtime: nodejs12.x
+      Environment:
+        Variables:
+          DATABASE: 
+          FETCHES_TABLE: 
+          PARQUET_TABLE:
+          S3_BUCKET_LOCATION: 
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function

--- a/functions/parquet/template.yaml
+++ b/functions/parquet/template.yaml
@@ -18,6 +18,11 @@ Resources:
       Handler: index.handler
       Runtime: nodejs12.x
       Timeout: 300 #5 minutes
+      Policies:
+        - AthenaQueryPolicy:
+            WorkGroupName: primary
+        - S3WritePolicy:
+            BucketName: #?
       Environment:
         Variables:
           DATABASE: 

--- a/functions/parquet/template.yaml
+++ b/functions/parquet/template.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  parquet
+
+  Sample SAM Template for parquet
+  
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 3
+
+Resources:
+  CreateParquetTable:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: create-parquet-table/
+      Handler: index.handler
+      Runtime: nodejs12.x
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  CreateParquetTable:
+    Description: "Create Parquet Table Lambda Function ARN"
+    Value: !GetAtt CreateParquetTable.Arn
+  CreateParquetTableIamRole:
+    Description: "Implicit IAM Role created for Create Parquet Table function"
+    Value: !GetAtt CreateParquetTable.Arn


### PR DESCRIPTION
### Overview
Used [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) to create a lambda function that will create a table from realtime gzipped data in a parquet format partitioned by parameter, outlined [here](https://github.com/openaq/openaq-fetch/issues/521). It creates the table in 3 min, 40 seconds and scans 9.3GB of data

### To test
```
cd parquet
sam build
sam local invoke --profile sam-deploy --env-vars env.json
```
where `sam-deploy` is the profile name with credentials stored in `~/.aws/credentials` and `env.json` is a file to keep environment variables like so: 
```
{
    "CreateParquetTable": {
        "DATABASE": "",
        "FETCHES_TABLE": "",
        "PARQUET_TABLE": "",
        "S3_BUCKET_LOCATION": ""
    }
}
```

### Remaining Work
- [x] Delete table before recreating (?)
- [x] Handle actual query execution success/fail (?)
- [x] Proper error handling
- [ ] ~Add trigger to run weekly~
- [ ] Set up env variables/deployment in Travis

Questions:
1. In order to run the CTAS query, the table must not already exist. If we want to run this every week to make sure the table is up to date, we will have to delete the table first. Is this acceptable? I don't see a huge problem with it because the underlying tables and data are still there and we can restrict permissions so nothing else is accidentally deleted. Although we'll have to make sure other services that reference the table aren't affected by this. 
**Note:** It only requires a `DROP TABLE`, the s3 bucket/folder doesn't need to be wiped, it just creates a new instance of the table.

2. Function only starts the query and only reports back if starting the query had any errors. In many instances while testing, the query went on to fail after successfully starting. How to handle this? 
    - Use [athena-express](https://github.com/ghdna/athena-express) wrapper instead of [aws javascript sdk](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Athena.html#startQueryExecution-property). This would mean the lambda function would be running for several minutes (not too costly but not the best design)
    - Have a separate lambda function that will be triggered if the query fails. This might be more work than it's worth.